### PR TITLE
Brew update on release

### DIFF
--- a/.github/workflows/macos-brew-release.yml
+++ b/.github/workflows/macos-brew-release.yml
@@ -2,7 +2,7 @@ name: macOS Brew Generate bump-formula-pr
 on:
   release:
     types: [published]
-    branches: [main,brew-update-on-release]
+    branches: [main]
 
 jobs:
   install_dependencies_and_build:

--- a/.github/workflows/macos-brew-release.yml
+++ b/.github/workflows/macos-brew-release.yml
@@ -1,4 +1,4 @@
-name: macOS Brew Building HEAD
+name: macOS Brew Generate bump-formula-pr
 on:
   release:
     types: [published]
@@ -10,5 +10,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Run everything
+        env: 
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.githubAccess }}
+          GITHUB_EMAIL: ${{ secrets.githubEmail }}      
         run: |
-             env
+             git config --global user.email "${GITHUB_EMAIL}"
+             git config --global user.name "${GITHUB_REPOSITORY_OWNER}"
+             brew update
+             URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/archive/${GITHUB_REF}.tar.gz"
+             curl "${URL}" -o download.tar.gz
+             CHECKSUM=$(shasum -a256 download.tar.gz | cut -c1-64)
+             brew bump-formula-pr --dry-run --no-browse --strict --online --url "${URL}" --sha256 "${CHECKSUM}"  timg

--- a/.github/workflows/macos-brew-release.yml
+++ b/.github/workflows/macos-brew-release.yml
@@ -1,0 +1,14 @@
+name: macOS Brew Building HEAD
+on:
+  release:
+    types: [published]
+    branches: [main,brew-update-on-release]
+
+jobs:
+  install_dependencies_and_build:
+    name: Print the environment 
+    runs-on: macos-latest
+    steps:
+      - name: Run everything
+        run: |
+             env

--- a/.github/workflows/macos-brew-release.yml
+++ b/.github/workflows/macos-brew-release.yml
@@ -1,5 +1,7 @@
 name: macOS Brew Generate bump-formula-pr
 on:
+  push:
+    branches: [brew-update-on-release]
   release:
     types: [published]
     branches: [main]
@@ -18,6 +20,7 @@ jobs:
              git config --global user.name "${GITHUB_REPOSITORY_OWNER}"
              brew update
              URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/archive/${GITHUB_REF}.tar.gz"
+             echo ${URL}
              curl "${URL}" -o download.tar.gz
              CHECKSUM=$(shasum -a256 download.tar.gz | cut -c1-64)
              brew bump-formula-pr --dry-run --no-browse --strict --online --url "${URL}" --sha256 "${CHECKSUM}"  timg

--- a/.github/workflows/macos-brew-release.yml
+++ b/.github/workflows/macos-brew-release.yml
@@ -19,6 +19,7 @@ jobs:
              git config --global user.email "${GITHUB_EMAIL}"
              git config --global user.name "${GITHUB_REPOSITORY_OWNER}"
              brew update
+             brew upgrade
              URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/archive/${GITHUB_REF}.tar.gz"
              echo ${URL}
              curl "${URL}" -o download.tar.gz


### PR DESCRIPTION
First attempt at automation of the brew bump-formula-pr execution, will trigger when a release is published on `main` branch. 

This workflow two secrets configured in the settings of the repo:
- `githubAccess` Needs to hold a GitHub token that will allow the brew command to for homebrew-core, create a branch, make changes to formula and create a PR.
-  `githubEmail` email address of repository owner for git config

This workflow will call the brew command with `--dry-run`, ie. it will print out steps instead of trying to fork the repo and creating the PR.