### PR TITLE
Downgrade required CMake version from 3.13 to 3.10.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 
 project(timg VERSION 1.4.0 LANGUAGES CXX)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,7 @@
 set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -Wno-unused-parameter -O3")
 
-add_executable(timg)
+add_executable(timg timg.cc)
 target_sources(timg PRIVATE
-  timg.cc
-
   buffered-write-sequencer.h buffered-write-sequencer.cc
   display-options.h
   framebuffer.h     framebuffer.cc


### PR DESCRIPTION
Allow out-of-the-box building in releases such as Ubuntu 18.04 LTS,
which ships with cmake 3.10, increasing timg's supported platforms
to most, if not all, major distros still within their life-cycles.

Fixes #53