### PR TITLE
Don't overwrite CXXFLAGS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -Wno-unused-parameter -O3")
+set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -Wno-unused-parameter -O3 ${CMAKE_CXX_FLAGS}")
 
 add_executable(timg timg.cc)
 target_sources(timg PRIVATE


### PR DESCRIPTION
Debian injects standard compilerflags (for hardening etc.). So
it is customary not to hardcode flags but also consider the ones from
the environement.