### PR TITLE
Clean mac os ci fix

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,8 +17,6 @@ jobs:
           brew install ffmpeg jpeg-turbo libexif libpng
           brew install openslide
           brew install pandoc
-          brew unlink jpeg
-          brew link --force jpeg-turbo
       - name: Get the Source
         uses: actions/checkout@v2
       - name: Build timg

--- a/README.md
+++ b/README.md
@@ -488,9 +488,6 @@ nix-shell
 # Homebrew needs to be available to install required dependencies
 brew install cmake git GraphicsMagick webp jpeg-turbo libexif  # needed libs
 
-# Work around glitch in pkg-config and jpeg-turbo.
-brew unlink jpeg && brew link --force jpeg-turbo
-
 # If you want to include video decoding, install these additional libraries
 brew install ffmpeg
 


### PR DESCRIPTION
Remove earlier workaround as it is no longer needed and now fails during building for macOS