### PR TITLE
Use correct ANSI colour range for grayscale pixel in 256color mode

### DIFF
--- a/src/framebuffer.h
+++ b/src/framebuffer.h
@@ -36,6 +36,11 @@ struct rgba_t {
 
     // Rough mapping to the 256 color modes, a 6x6x6 cube.
     inline uint8_t As256TermColor() const {
+        if (r == g && g == b) {
+            // gray scale, using the 232-255 range.
+            return 232 + (r * 23 / 255);
+        }
+
         auto v2cube = [](uint8_t v) {  // middle of cut-off points for cube.
             return v < 0x5f / 2            ? 0
                    : v < (0x5f + 0x87) / 2 ? 1


### PR DESCRIPTION
See the following example:
![example](https://user-images.githubusercontent.com/22362177/204972019-211b2764-d17b-4517-b396-2f497e351a1d.png)

-----------------
Before:
![before](https://user-images.githubusercontent.com/22362177/204972038-7b130b19-2b73-4216-a85b-3428ad42332e.png)

-----------------
After:
![after](https://user-images.githubusercontent.com/22362177/204972060-52e2b2cc-a14b-4fa4-8d5c-0de2856477dc.png)

