### PR TITLE
Fix typo: s/performace/performance

### DIFF
--- a/man/timg.1
+++ b/man/timg.1
@@ -374,7 +374,7 @@ Page through detailed manpage-like help and exit.
 Don\[cq]t delay frames in videos or animations but emit as fast as
 possible.
 This might be useful for developers of terminal emulations to do
-performace tests or simply if you want to redirect the output to a file
+performance tests or simply if you want to redirect the output to a file
 and don\[cq]t want to wait.
 .SS For Animations, Scrolling, or Video
 Usually, animations are shown in full in an infinite loop.

--- a/man/timg.1.md
+++ b/man/timg.1.md
@@ -311,9 +311,9 @@ Most likely commonly needed options first.
 
 **-\-debug-no-frame-delay**
 :    Don't delay frames in videos or animations but emit as fast as possible.
-     This might be useful for developers of terminal emulations to do performace
-     tests or simply if you want to redirect the output to a file and don't
-     want to wait.
+     This might be useful for developers of terminal emulations to do
+     performance tests or simply if you want to redirect the output to a file
+     and don't want to wait.
 
 ## For Animations, Scrolling, or Video
 


### PR DESCRIPTION
a quick typo fix found by Debian's lintian tool.