### PR TITLE
timg.cc: define __STDC_FORMAT_MACROS if undefined

### DIFF
--- a/src/timg.cc
+++ b/src/timg.cc
@@ -61,6 +61,10 @@
 #include <poppler.h>
 #endif
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 // The following is to work around clang-tidy being confused and not
 // understanding that unistd.h indeed provides getopt(). So let's include
 // unistd.h for correctness, and then soothe clang-tidy with decls.


### PR DESCRIPTION
Change of the header to `<cinttypes>` fixes the build with GCC, but some older clangs (and possibly other compilers) need `__STDC_FORMAT_MACROS` even then, so just define it to be on the safe side.