### PR TITLE
Remove unnecessary sixel sequence wrapper.

### DIFF
--- a/src/sixel-canvas.cc
+++ b/src/sixel-canvas.cc
@@ -127,7 +127,6 @@ void SixelCanvas::Send(int x, int dy, const Framebuffer &fb_orig,
 
             OutBuffer out(buffer, offset - buffer);
             WriteStringToOutBuffer(cursor_handling_start, &out);
-            WriteStringToOutBuffer("\033Pq", &out);  // Start sixel data
             sixel_output_t *sixel_out = nullptr;
             sixel_output_new(&sixel_out, WriteToOutBuffer, &out, nullptr);
 
@@ -144,7 +143,6 @@ void SixelCanvas::Send(int x, int dy, const Framebuffer &fb_orig,
             sixel_dither_destroy(sixel_dither);
             sixel_output_destroy(sixel_out);
 
-            WriteStringToOutBuffer("\033\\", &out);  // end sixel data
             WriteStringToOutBuffer(cursor_handling_end, &out);
             return out;
         };


### PR DESCRIPTION
The `sixel_encode` function will already generate a complete Sixel
sequence, so there is no need to wrap that with an additional sequence
introducer and terminator, and doing so can cause problems on some
terminals.
