### PR TITLE
Remove the call to the deprecated method `avcodec_close`

### DIFF
--- a/src/video-source.cc
+++ b/src/video-source.cc
@@ -111,7 +111,6 @@ VideoSource::VideoSource(const std::string &filename) : ImageSource(filename) {
 
 VideoSource::~VideoSource() {
     sws_freeContext(sws_context_);
-    avcodec_close(codec_context_);
     avcodec_free_context(&codec_context_);
     avformat_close_input(&format_context_);
     delete terminal_fb_;


### PR DESCRIPTION
Deprecated in ffmpeg 7.0: https://ffmpeg.org/doxygen/7.0/deprecated.html#_deprecated000003 and completely removed in the current truck (will cause the code to not compile).